### PR TITLE
Migrate to Modern Dependencies

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -11,20 +11,20 @@ for the software used under the respective license be made available. If you
 would like to receive a copy of such source code, please send an email to
 michael at herrmann (double r, double n) dot io.
 
-PyQt5
+PyQt6
 =====
 URL: https://riverbankcomputing.com/software/pyqt/intro
-Version: 5.9.2
+Version: 6.6.1
 
 Imported by some of fbs's Python files.
 
 Used under the terms of the GNU General Public License version 3. The license
 text can be found in the LICENSE file.
 
-PySide2
+PySide6
 =======
 URL: https://wiki.qt.io/Qt_for_Python
-Version: 5.12.0
+Version: 6.6.1
 
 Imported by some of fbs's Python files.
 
@@ -34,9 +34,9 @@ A copy of the license is available at http://www.gnu.org/.
 Qt
 ==
 URL: https://www.qt.io
-Version: 5
+Version: 6
 
-Used indirectly, through PyQt5 or PySide2, from fbs's Python code.
+Used indirectly, through PyQt6 or PySide6, from fbs's Python code.
 
 Used under the terms of the GNU Lesser General Public License version 3.
 A copy of the license is available at http://www.gnu.org/.

--- a/fbs/__init__.py
+++ b/fbs/__init__.py
@@ -19,9 +19,9 @@ def init(project_dir):
     Call this if you are invoking neither `fbs` on the command line nor
     fbs.cmdline.main() from Python.
     """
-    if sys.version_info[0] != 3 or sys.version_info[1] != 8:
+    if sys.version_info[0] != 3 or sys.version_info[1] < 8:
         raise FbsError(
-            'This modification of the free version of fbs only supports Python 3.8.\n'
+            'This modification of the free version of fbs only supports Python > 3.8.\n'
         )
     SETTINGS.update(get_core_settings(abspath(project_dir)))
     for profile in get_default_profiles():

--- a/fbs/_defaults/requirements/arch.txt
+++ b/fbs/_defaults/requirements/arch.txt
@@ -1,4 +1,4 @@
 -r linux.txt
 # PyQt5==5.11 currently gives an error when we deploy and run the frozen app:
 #     No module named 'PyQt5.sip'
-PyQt5<5.11
+#PyQt5<5.11

--- a/fbs/_defaults/requirements/ubuntu.txt
+++ b/fbs/_defaults/requirements/ubuntu.txt
@@ -1,2 +1,2 @@
 -r linux.txt
-PyQt5==5.9.2
+#PyQt5==5.9.2

--- a/fbs/_defaults/src/freeze/mac/Contents/Info.plist
+++ b/fbs/_defaults/src/freeze/mac/Contents/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>CFBundleExecutable</key>
-    <string>${app_name}</string>
+    <string>${app_name}-mac</string>
     <key>CFBundleDisplayName</key>
     <string>${app_name}</string>
     <key>CFBundlePackageType</key>

--- a/fbs/builtin_commands/__init__.py
+++ b/fbs/builtin_commands/__init__.py
@@ -36,15 +36,15 @@ def startproject():
     app = prompt_for_value('App name', default='MyApp')
     user = getuser().title()
     author = prompt_for_value('Author', default=user)
-    has_pyqt = _has_module('PyQt5')
-    has_pyside = _has_module('PySide2')
+    has_pyqt = _has_module('PyQt6')
+    has_pyside = _has_module('PySide6')
     if has_pyqt and not has_pyside:
-        python_bindings = 'PyQt5'
+        python_bindings = 'PyQt6'
     elif not has_pyqt and has_pyside:
-        python_bindings = 'PySide2'
+        python_bindings = 'PySide6'
     else:
         python_bindings = prompt_for_value(
-            'Qt bindings', choices=('PyQt5', 'PySide2'), default='PyQt5'
+            'Qt bindings', choices=('PyQt6', 'PySide6'), default='PyQt6'
         )
     eg_bundle_id = 'com.%s.%s' % (
         author.lower().split()[0], ''.join(app.lower().split())
@@ -81,11 +81,11 @@ def run():
     Run your app from source
     """
     require_existing_project()
-    if not _has_module('PyQt5') and not _has_module('PySide2'):
+    if not _has_module('PyQt6') and not _has_module('PySide6'):
         raise FbsError(
-            "Couldn't find PyQt5 or PySide2. Maybe you need to:\n"
-            "    pip install PyQt5==5.9.2 or\n"
-            "    pip install PySide2==5.12.2"
+            "Couldn't find PyQt6 or PySide6. Maybe you need to:\n"
+            "    pip install PyQt6==6.6.1 or\n"
+            "    pip install PySide6==6.6.2"
         )
     env = dict(os.environ)
     pythonpath = path('src/main/python')

--- a/fbs/freeze/hooks/hook-PySide2.py
+++ b/fbs/freeze/hooks/hook-PySide2.py
@@ -20,7 +20,7 @@ Then, it prints Signature('QStringList') instead of the above ...(List).
 from glob import glob
 from os.path import dirname, relpath, join
 
-import PySide2.support
+import PySide6.support
 
 """
 This should give roughly the same results as:
@@ -34,7 +34,7 @@ The reason we don't do it this way is that it would add a dynamic link to
 PyInstaller, and thus force the GPL on fbs, preventing it from being licensed
 under different terms (such as a commercial license).
 """
-_base_dir = dirname(PySide2.support.__file__)
+_base_dir = dirname(PySide6.support.__file__)
 _python_files = glob(join(_base_dir, '**', '*.py'), recursive=True)
 _site_packages = dirname(dirname(_base_dir))
 datas = [(f, relpath(dirname(f), _site_packages)) for f in _python_files]

--- a/fbs/freeze/hooks/hook-shiboken2.py
+++ b/fbs/freeze/hooks/hook-shiboken2.py
@@ -1,12 +1,12 @@
 from glob import glob
 from os.path import dirname, relpath, join
 
-import PySide2
+import PySide6
 
 support = None
 
-if PySide2.__version__ == "5.12.2":
-    import PySide2.support as support
+if PySide6.__version__ == "6.6.2":
+    import PySide6.support as support
 else:
     try:
         # PySide2 < 5.12.2

--- a/fbs/freeze/mac.py
+++ b/fbs/freeze/mac.py
@@ -55,6 +55,6 @@ def _fix_sparkle_delta_updates():
         path('${freeze_dir}/Contents/Resources/base_library.zip')
     )
     symlink(
-        path('${freeze_dir}/Contents/Resources/base_library.zip',
+        path('${freeze_dir}/Contents/Resources/base_library.zip'),
         path('${freeze_dir}/Contents/MacOS/base_library.zip')
     )

--- a/fbs/freeze/mac.py
+++ b/fbs/freeze/mac.py
@@ -55,6 +55,6 @@ def _fix_sparkle_delta_updates():
         path('${freeze_dir}/Contents/Resources/base_library.zip')
     )
     symlink(
-        '../Resources/base_library.zip',
+        path('${freeze_dir}/Contents/Resources/base_library.zip',
         path('${freeze_dir}/Contents/MacOS/base_library.zip')
     )

--- a/fbs/freeze/mac.py
+++ b/fbs/freeze/mac.py
@@ -21,7 +21,7 @@ def freeze_mac(debug=False):
         ])
     run_pyinstaller(args, debug)
     _remove_unwanted_pyinstaller_files()
-    _fix_sparkle_delta_updates()
+    #_fix_sparkle_delta_updates()
     _generate_resources()
 
 def _generate_iconset():
@@ -44,17 +44,17 @@ def _remove_unwanted_pyinstaller_files():
         except FileNotFoundError:
             pass
 
-def _fix_sparkle_delta_updates():
+#def _fix_sparkle_delta_updates():
     # Sparkle's Delta Updates mechanism does not support signed non-Mach-O files
     # in Contents/MacOS. base_library.zip, which is created by PyInstaller,
     # violates this. We therefore move base_library.zip to Contents/Resources.
     # Fortunately, everything still works if we then create a symlink
     # MacOS/base_library.zip -> ../Resources/base_library.zip.
-    rename(
-        path('${freeze_dir}/Contents/MacOS/base_library.zip'),
-        path('${freeze_dir}/Contents/Resources/base_library.zip')
-    )
-    symlink(
-        path('${freeze_dir}/Contents/Resources/base_library.zip'),
-        path('${freeze_dir}/Contents/MacOS/base_library.zip')
-    )
+    #rename(
+    #    path('${freeze_dir}/Contents/MacOS/base_library.zip'),
+    #    path('${freeze_dir}/Contents/Resources/base_library.zip')
+    #)
+    #symlink(
+    #    path('${freeze_dir}/Contents/Resources/base_library.zip'),
+    #    path('${freeze_dir}/Contents/MacOS/base_library.zip')
+    #)

--- a/fbs/freeze/mac.py
+++ b/fbs/freeze/mac.py
@@ -21,7 +21,6 @@ def freeze_mac(debug=False):
         ])
     run_pyinstaller(args, debug)
     _remove_unwanted_pyinstaller_files()
-    #_fix_sparkle_delta_updates()
     _generate_resources()
 
 def _generate_iconset():
@@ -43,18 +42,3 @@ def _remove_unwanted_pyinstaller_files():
             rmtree(path('${freeze_dir}/Contents/Resources/' + unwanted))
         except FileNotFoundError:
             pass
-
-#def _fix_sparkle_delta_updates():
-    # Sparkle's Delta Updates mechanism does not support signed non-Mach-O files
-    # in Contents/MacOS. base_library.zip, which is created by PyInstaller,
-    # violates this. We therefore move base_library.zip to Contents/Resources.
-    # Fortunately, everything still works if we then create a symlink
-    # MacOS/base_library.zip -> ../Resources/base_library.zip.
-    #rename(
-    #    path('${freeze_dir}/Contents/MacOS/base_library.zip'),
-    #    path('${freeze_dir}/Contents/Resources/base_library.zip')
-    #)
-    #symlink(
-    #    path('${freeze_dir}/Contents/Resources/base_library.zip'),
-    #    path('${freeze_dir}/Contents/MacOS/base_library.zip')
-    #)

--- a/fbs/installer/mac/create-dmg/create-dmg
+++ b/fbs/installer/mac/create-dmg/create-dmg
@@ -357,7 +357,7 @@ echo "Done fixing permissions."
 # make the top window open itself on mount:
 if [ $SANDBOX_SAFE -eq 0 ]; then
 	echo "Blessing started"
-	bless --folder "${MOUNT_DIR}" --openfolder "${MOUNT_DIR}"
+	bless --folder "${MOUNT_DIR}"
 	echo "Blessing finished"
 else
 	echo "Skipping blessing on sandbox"

--- a/fbs_runtime/application_context/PyQt6.py
+++ b/fbs_runtime/application_context/PyQt6.py
@@ -21,9 +21,9 @@ only package the one necessary library, and prevents the above problems.
 """
 
 from . import _ApplicationContext, _QtBinding, cached_property
-from PySide2.QtGui import QIcon
-from PySide2.QtWidgets import QApplication
-from PySide2.QtNetwork import QAbstractSocket
+from PyQt6.QtGui import QIcon
+from PyQt6.QtWidgets import QApplication
+from PyQt6.QtNetwork import QAbstractSocket
 
 class ApplicationContext(_ApplicationContext):
     @cached_property

--- a/fbs_runtime/application_context/PySide6.py
+++ b/fbs_runtime/application_context/PySide6.py
@@ -21,9 +21,9 @@ only package the one necessary library, and prevents the above problems.
 """
 
 from . import _ApplicationContext, _QtBinding, cached_property
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QApplication
-from PyQt5.QtNetwork import QAbstractSocket
+from PySide6.QtGui import QIcon
+from PySide6.QtWidgets import QApplication
+from PySide6.QtNetwork import QAbstractSocket
 
 class ApplicationContext(_ApplicationContext):
     @cached_property

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyQt5==5.15.10
+PySide6=6.6.1
 PyInstaller==6.4.0
 rsa>=3.4.2
 boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyQt5==5.15.10
-PyInstaller==5.13.2
+PyInstaller==6.4.0
 rsa>=3.4.2
 boto3
 sentry-sdk>=0.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyQt5==5.12.3
-PyInstaller==4.10
+PyInstaller==5.13.2
 rsa>=3.4.2
 boto3
 sentry-sdk>=0.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyQt5==5.12.3
-PyInstaller==4.4
+PyInstaller==4.10
 rsa>=3.4.2
 boto3
 sentry-sdk>=0.6.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyQt5==5.12.3
+PyQt5==5.15.10
 PyInstaller==5.13.2
 rsa>=3.4.2
 boto3

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
             'fbs/installer/mac', 'create-dmg'
         )
     },
-    install_requires=['PyInstaller==4.4'],
+    install_requires=['PyInstaller==4.10'],
     extras_require={
         # Also update requirements.txt when you change this:
         'licensing': ['rsa>=3.4.2'],

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
             'fbs/installer/mac', 'create-dmg'
         )
     },
-    install_requires=['PyInstaller==5.13.2'],
+    install_requires=['PyInstaller===6.4.0'],
     extras_require={
         # Also update requirements.txt when you change this:
         'licensing': ['rsa>=3.4.2'],

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
             'fbs/installer/mac', 'create-dmg'
         )
     },
-    install_requires=['PyInstaller==4.10'],
+    install_requires=['PyInstaller==5.13.2'],
     extras_require={
         # Also update requirements.txt when you change this:
         'licensing': ['rsa>=3.4.2'],

--- a/tests/test_fbs/__init__.py
+++ b/tests/test_fbs/__init__.py
@@ -17,7 +17,7 @@ class FbsTest(TestCase):
         self._project_dir = join(self._tmp_dir.name, 'project')
         project_template = \
             join(dirname(fbs.builtin_commands.__file__), 'project_template')
-        replacements = { 'python_bindings': 'PyQt5' }
+        replacements = { 'python_bindings': 'PySide6' }
         filter_ = [join(project_template, 'src', 'main', 'python', 'main.py')]
         copy_with_filtering(
             project_template, self._project_dir, replacements, filter_

--- a/tests/test_fbs/builtin_commands/test___init__.py
+++ b/tests/test_fbs/builtin_commands/test___init__.py
@@ -9,7 +9,7 @@ class BuiltInCommandsTest(FbsTest):
     def test_freeze_installer(self):
         freeze()
         if is_mac():
-            executable = path('${freeze_dir}/Contents/MacOS/${app_name}')
+            executable = path('${freeze_dir}/Contents/MacOS/${app_name}-mac')
         elif is_windows():
             executable = path('${freeze_dir}/${app_name}.exe')
         else:


### PR DESCRIPTION
This PR brings the following updates:
- Migrate from Qt5 to Qt6
- Update supported Python versions to 3.8+ [instead of locked to 3.8]
- Upgrade PyInstaller from 4.4 to 6.4, the latest at the time of this PR.
- Address some inconsistencies in app naming requirements on mac

This, along with a sister PR on AYAB-Desktop (AllYarnsAreBeautiful/ayab-desktop#572), should fix release builds for us going forward.